### PR TITLE
fixed ambiguity in workflows

### DIFF
--- a/.github/workflows/tauri-test.yml
+++ b/.github/workflows/tauri-test.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Test and clippy rust
         run: |
           cargo test --release --workspace --exclude app
-          cargo clippy --release --workspace
+          cargo clippy --release --workspace --exclude app
         working-directory: src-tauri
 
       - name: Build tauri

--- a/.github/workflows/tauri-test.yml
+++ b/.github/workflows/tauri-test.yml
@@ -41,8 +41,8 @@ jobs:
 
       - name: Test and clippy rust
         run: |
-          cargo test --release --package chem-eq --package chatelier
-          cargo clippy --release --package chem-eq --package chatelier
+          cargo test --release --workspace
+          cargo clippy --release --workspace
         working-directory: src-tauri
 
       - name: Build tauri

--- a/.github/workflows/tauri-test.yml
+++ b/.github/workflows/tauri-test.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Test and clippy rust
         run: |
-          cargo test --release --workspace
+          cargo test --release --workspace --exclude app
           cargo clippy --release --workspace
         working-directory: src-tauri
 


### PR DESCRIPTION
Cargo was complaining it didn't know whether to use online or offline version of chem-eq to test. This should help